### PR TITLE
[AIRSHIP-2874] Update CronJob and PodDisruptionBudget API versions from v1beta1 to v1

### DIFF
--- a/examples/cron.yaml
+++ b/examples/cron.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: surtr


### PR DESCRIPTION
The v1beta1 api versions for CronJobs and PodDisruptionBudgets are being deprecated in Kubernetes 1.25. This updates both versions to v1

[_Created by Sourcegraph batch change `meghaniankov/cronjob-pdb-api-change`._](https://rvu.sourcegraph.com/users/meghaniankov/batch-changes/cronjob-pdb-api-change)